### PR TITLE
Fixes rank_cost_<rank> placeholder

### DIFF
--- a/src/com/extendedclip/papi/expansion/ezrp/EZRPExpansion.java
+++ b/src/com/extendedclip/papi/expansion/ezrp/EZRPExpansion.java
@@ -68,16 +68,38 @@ public class EZRPExpansion extends PlaceholderExpansion {
 			rank = identifier.replace("rank_cost_formatted_", "");
 
 			r = Rankup.getRankup(rank);
+			if (r == null) {
+				return null;
+			}
 
-			return r != null ? EcoUtil.fixMoney(r.getCost()) : null;
+			double cost = r.getCost();
+
+			if (player != null && player.isOnline()) {
+				Player onlinePlayer = player.getPlayer();
+				cost = CostHandler.getMultiplier(onlinePlayer, cost);
+				cost = CostHandler.getDiscount(onlinePlayer, cost);
+			}
+
+			return EcoUtil.fixMoney(cost);
 		}
 
 		if (identifier.startsWith("rank_cost_")) {
 			rank = identifier.replace("rank_cost_", "");
 
 			r = Rankup.getRankup(rank);
+			if (r == null) {
+				return null;
+			}
 
-			return r != null ? String.valueOf(r.getCost()) : null;
+			double cost = r.getCost();
+
+			if (player != null && player.isOnline()) {
+				Player onlinePlayer = player.getPlayer();
+				cost = CostHandler.getMultiplier(onlinePlayer, cost);
+				cost = CostHandler.getDiscount(onlinePlayer, cost);
+			}
+
+			return String.valueOf(cost);
 		}
 
 		if (identifier.startsWith("rank_prefix_")) {

--- a/src/com/extendedclip/papi/expansion/ezrp/EZRPExpansion.java
+++ b/src/com/extendedclip/papi/expansion/ezrp/EZRPExpansion.java
@@ -56,7 +56,7 @@ public class EZRPExpansion extends PlaceholderExpansion {
 
 	@Override
 	public String getVersion() {
-		return "1.2.0";
+		return "1.2.1";
 	}
 
 	@Override


### PR DESCRIPTION
- Fixes #4, `%ezrankspro_rank_cost_<rank>%` and `%ezrankspro_rank_cost_formatted_<rank>%` not returning the cost with the multiplier and the discount.